### PR TITLE
Skal kunne kalle put-endepunkt uten body

### DIFF
--- a/http-client/main/no/nav/tilleggsstonader/libs/http/client/AbstractRestClient.kt
+++ b/http-client/main/no/nav/tilleggsstonader/libs/http/client/AbstractRestClient.kt
@@ -41,6 +41,13 @@ abstract class AbstractRestClient(val restTemplate: RestTemplate) {
         uriVariables: Map<String, *> = emptyMap<String, String>(),
     ): T? = executeNullable(uri, HttpMethod.POST, HttpEntity(payload, httpHeaders), uriVariables)
 
+    inline fun <reified T : Any> putForEntityNullable(
+        uri: String,
+        payload: Any,
+        httpHeaders: HttpHeaders? = null,
+        uriVariables: Map<String, *> = emptyMap<String, String>(),
+    ): T? = executeNullable(uri, HttpMethod.PUT, HttpEntity(payload, httpHeaders), uriVariables)
+
     inline fun <reified T : Any> putForEntity(
         uri: String,
         payload: Any,

--- a/http-client/test/no/nav/tilleggsstonader/libs/http/client/AbstractRestClientTest.kt
+++ b/http-client/test/no/nav/tilleggsstonader/libs/http/client/AbstractRestClientTest.kt
@@ -51,6 +51,9 @@ internal class AbstractRestClientTest {
         fun postUtenResponseBody(): String? {
             return postForEntityNullable<String>(uri.toString(), emptyMap<String, String>())
         }
+        fun putUtenResponseBody(): String? {
+            return putForEntityNullable<String>(uri.toString(), emptyMap<String, String>())
+        }
     }
 
     companion object {
@@ -115,6 +118,16 @@ internal class AbstractRestClientTest {
         )
 
         assertThat(client.postUtenResponseBody()).isNull()
+    }
+
+    @Test
+    fun `skal kunne kalle på put-endepunkt og forvente svar uten body`() {
+        wireMockServer.stubFor(
+            WireMock.put(anyUrl())
+                .willReturn(created()),
+        )
+
+        assertThat(client.putUtenResponseBody()).isNull()
     }
 
     @Test


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne kalle https://dokarkiv.dev.intern.nav.no/swagger-ui/index.html#/journalpostapi%20-%20logiske%20vedlegg/bulkOppdaterLogiskVedlegg uten at det fieler pga. manglengde body