### PR TITLE
Legger til funksjon som returnerer dagens dato i Oslo

### DIFF
--- a/util/main/no/nav/tilleggsstonader/libs/utils/DatoUtil.kt
+++ b/util/main/no/nav/tilleggsstonader/libs/utils/DatoUtil.kt
@@ -1,8 +1,10 @@
 package no.nav.tilleggsstonader.libs.utils
 
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 val ZONE_ID_OSLO: ZoneId = ZoneId.of("Europe/Oslo")
 
 fun osloNow(): LocalDateTime = LocalDateTime.now(ZONE_ID_OSLO)
+fun osloDateNow(): LocalDate = LocalDate.now(ZONE_ID_OSLO)


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Legger til funksjon som returnerer dagens dato i Oslo.

Sees i sammenheng med PRs:
https://github.com/navikt/tilleggsstonader-integrasjoner/pull/91
https://github.com/navikt/tilleggsstonader-sak/pull/303/
https://github.com/navikt/tilleggsstonader-soknad-api/pull/120