### PR TITLE
Workaround/fiks for exception-propagering ved bruk av CacheManager direkte

### DIFF
--- a/spring/test/no/nav/tilleggsstonader/libs/spring/cache/CacheUtilKtTest.kt
+++ b/spring/test/no/nav/tilleggsstonader/libs/spring/cache/CacheUtilKtTest.kt
@@ -4,6 +4,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -20,6 +21,18 @@ class CacheUtilKtTest {
     @BeforeEach
     internal fun setUp() {
         every { mock.getValue(any()) } answers { firstArg<List<Int>>().associateWith { it } }
+    }
+
+    @Nested
+    inner class GetValue {
+        @Test
+        internal fun `exception som kastes fra valueLoader skal propageres opp`() {
+            val forventetException = Exception("oh noo")
+
+            assertThatException()
+                .isThrownBy { cacheManager.getValue<String, Any>("noe", "key123") { throw forventetException } }
+                .isEqualTo(forventetException)
+        }
     }
 
     @Nested


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ved bruk av CacheManager direkte, så vil et exception som kastes fra en valueLoader-funksjon bli pakket inn i et `Cache.ValueRetrievalException`. Dette kan videre føre til at et http-request returnerer en 500-status, selv om det egentlig skulle ha vært en 400-status. Dette er ikke tilfelle når man bruker Cacheable-annotasjonen til spring, da propageres det originale exceptionet.
