### PR TITLE
Lagt til annotasjonen KotlinTransactional som ruller tilbake på alle …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 val javaVersion = JavaLanguageVersion.of(21)
 
 plugins {
@@ -63,6 +66,12 @@ subprojects {
 
     tasks.test {
         useJUnitPlatform()
+        testLogging {
+            events = setOf(TestLogEvent.FAILED)
+            exceptionFormat = TestExceptionFormat.FULL
+            showStackTraces = false
+            showCauses = false
+        }
     }
 
     java {

--- a/spring/build.gradle.kts
+++ b/spring/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 plugins {
     kotlin("plugin.spring") version "2.1.20"
 }
@@ -5,7 +8,14 @@ plugins {
 dependencies {
     implementation("org.springframework.boot:spring-boot")
     implementation("org.springframework:spring-web")
+    implementation("org.springframework:spring-jdbc")
     implementation("org.slf4j:slf4j-api")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        exclude(module = "mockito-core")
+    }
+    testImplementation("org.junit.platform:junit-platform-suite")
+    testImplementation("com.h2database:h2")
 }
 
 tasks.sourcesJar {

--- a/spring/main/no/nav/tilleggsstonader/libs/spring/transaction/KotlinTransactional.kt
+++ b/spring/main/no/nav/tilleggsstonader/libs/spring/transaction/KotlinTransactional.kt
@@ -1,0 +1,14 @@
+package no.nav.tilleggsstonader.libs.spring.transaction
+
+import org.springframework.core.annotation.AliasFor
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.KClass
+
+@Transactional
+annotation class KotlinTransactional(
+    @get:AliasFor(annotation = Transactional::class, attribute = "rollbackFor")
+    val rollbackFor: Array<KClass<out Throwable>> = [Exception::class],
+    @get:AliasFor(annotation = Transactional::class, attribute = "propagation")
+    val propagation: Propagation = Propagation.REQUIRED,
+)

--- a/spring/test/no/nav/tilleggsstonader/libs/spring/transaction/KotlinTransactionalTest.kt
+++ b/spring/test/no/nav/tilleggsstonader/libs/spring/transaction/KotlinTransactionalTest.kt
@@ -1,0 +1,87 @@
+package no.nav.tilleggsstonader.libs.spring.transaction
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.PlatformTransactionManager
+import java.io.IOException
+import javax.sql.DataSource
+
+@SpringBootApplication
+class TestApplication
+
+@SpringBootTest(classes = [TestApplication::class, KotlinTransactionalTest.TestConfig::class])
+class KotlinTransactionalTest {
+    @Autowired
+    private lateinit var service: KotlinTransactionalTestService
+
+    @Autowired
+    private lateinit var jdbcTemplate: JdbcTemplate
+
+    @BeforeEach
+    fun setUp() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS TEST_TABLE")
+        jdbcTemplate.execute("CREATE TABLE TEST_TABLE (id SERIAL PRIMARY KEY, data VARCHAR(255))")
+    }
+
+    @Test
+    fun `happy case`() {
+        service.lagre("testverdi")
+
+        assertThat(hentAntallRader()).isEqualTo(1)
+    }
+
+    @Test
+    fun `skal rulle tilbake når checked exception IOException kastes`() {
+        val exception =
+            try {
+                service.lagreMedFeil("testverdi")
+            } catch (e: Exception) {
+                e
+            }
+
+        assertThat(hentAntallRader()).isEqualTo(0)
+        assertThat(exception).isInstanceOf(IOException::class.java)
+    }
+
+    private fun hentAntallRader(): Int? = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM TEST_TABLE", Int::class.java)
+
+    class TestConfig {
+        @Bean
+        fun dataSource(): DataSource =
+            EmbeddedDatabaseBuilder()
+                .setType(EmbeddedDatabaseType.H2)
+                .build()
+
+        @Bean
+        fun transactionManager(dataSource: DataSource): PlatformTransactionManager = DataSourceTransactionManager(dataSource)
+
+        @Bean
+        fun jdbcTemplate(dataSource: DataSource): JdbcTemplate = JdbcTemplate(dataSource)
+    }
+}
+
+@Service
+class KotlinTransactionalTestService(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+    @KotlinTransactional
+    fun lagre(data: String) {
+        jdbcTemplate.update("INSERT INTO TEST_TABLE (data) VALUES (?)", data)
+    }
+
+    @KotlinTransactional
+    fun lagreMedFeil(data: String) {
+        jdbcTemplate.update("INSERT INTO TEST_TABLE (data) VALUES (?)", data)
+        throw IOException("Simulert feil")
+    }
+}


### PR DESCRIPTION
…type Exception og ikke kun RuntimeException

- @Rollback ruller ikke tilbake for checked exceptions og Kotlin håndterer alle exceptions som checked i den forstand at man ikke må si hvilken type checked exception en metode kaster som i Java, og då ikke trenger å håndtere den

### Hvorfor er denne endringen nødvendig? ✨

Man kan havne i situasjonen der man har en metode:
```kotlin
@Transactional
fun johan() {
  lagrerSøknadTilDatabase()
  annenMetodeSomFeiler() // feiler med checked exception
  oppretterOppgave()
}
```
I dette tilfelle vil lagre søknad gå OK, og ikke bli rullet tilbake då `@Transactional` ikke ruller tilbake eks `IOException`
Då får vi ikke opprettet oppgaven og andre ting vi hadde forventet skulle bli opprettet

Også nevnt her https://nav-it.slack.com/archives/C73B9LC86/p1744096571722879

Forslaget er å erstatte alle `@Transactional` med `@KotlinTransactional` for å unngå at dette skal skje
