### PR TITLE
Fjerner warning-logg i RequestTimeFilter, da det ellers logges feil fra requests i ControllerAdvice og det da bare blir støy om det logges warning her og

### DIFF
--- a/log/main/no/nav/tilleggsstonader/libs/log/filter/RequestTimeFilter.kt
+++ b/log/main/no/nav/tilleggsstonader/libs/log/filter/RequestTimeFilter.kt
@@ -29,18 +29,14 @@ class RequestTimeFilter : HttpFilter() {
         code: Int,
         timer: StopWatch,
     ) {
-        if (HttpStatus.valueOf(code).isError) {
-            LOG.warn("{} - {} - ({}). Dette tok {}ms", request.method, request.requestURI, code, timer.totalTimeMillis)
-        } else {
-            if (!shouldNotFilter(request.requestURI)) {
-                LOG.info(
-                    "{} - {} - ({}). Dette tok {}ms",
-                    request.method,
-                    request.requestURI,
-                    code,
-                    timer.totalTimeMillis,
-                )
-            }
+        if (!shouldNotFilter(request.requestURI)) {
+            LOG.info(
+                "{} - {} - ({}). Dette tok {}ms",
+                request.method,
+                request.requestURI,
+                code,
+                timer.totalTimeMillis,
+            )
         }
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

For hvert exception som fører til 400-logg så logges det minst to warnings. Et i ControllerAdvice og et i RequestTimeFilter. 

RequestTimeFilter brukes helst for å time endepunkt, tenker det er unødvendig at det skal logges warning her og 👀 