### PR TITLE
🩹 Legg til OAuth2 timeout properties og forbedret retry-logging

### DIFF
--- a/http-client/main/no/nav/tilleggsstonader/libs/http/client/RetryOAuth2HttpClient.kt
+++ b/http-client/main/no/nav/tilleggsstonader/libs/http/client/RetryOAuth2HttpClient.kt
@@ -68,17 +68,26 @@ class RetryOAuth2HttpClient(
         retries: Int,
         oAuth2HttpRequest: OAuth2HttpRequest,
     ) {
-        if (shouldRetry(e) && retries < maxRetries) {
-            logger.warn(
-                "Kall mot url=${oAuth2HttpRequest.tokenEndpointUrl} feilet, cause=${
-                    NestedExceptionUtils.getMostSpecificCause(e)::class
-                }",
+        val mostSpecificCause = NestedExceptionUtils.getMostSpecificCause(e)
+        if (shouldRetry(mostSpecificCause) && retries < maxRetries) {
+            logger.info(
+                "Kall mot url=${oAuth2HttpRequest.tokenEndpointUrl} feilet på forsøk=${retries + 1}, retryer, cause=${mostSpecificCause::class}",
             )
-            secureLogger.warn("Kall mot url=${oAuth2HttpRequest.tokenEndpointUrl} feilet med feil=${e.message}")
-        } else {
-            throw e
+            secureLogger.info(
+                "Kall mot url=${oAuth2HttpRequest.tokenEndpointUrl} feilet på forsøk=${retries + 1}, retryer, feil=${e.message}",
+            )
+            return
         }
+
+        if (shouldRetry(mostSpecificCause) && retries > 0) {
+            logger.warn(
+                "Kall mot url=${oAuth2HttpRequest.tokenEndpointUrl} feilet etter ${retries + 1} forsøk, cause=${mostSpecificCause::class}",
+            )
+            secureLogger.warn("Kall mot url=${oAuth2HttpRequest.tokenEndpointUrl} feilet etter ${retries + 1} forsøk, feil=${e.message}")
+        }
+
+        throw e
     }
 
-    private fun shouldRetry(e: Exception): Boolean = retryExceptions.contains(e.cause?.let { it::class })
+    private fun shouldRetry(throwable: Throwable): Boolean = retryExceptions.any { it.java.isInstance(throwable) }
 }

--- a/http-client/main/no/nav/tilleggsstonader/libs/http/config/HttpClientProperties.kt
+++ b/http-client/main/no/nav/tilleggsstonader/libs/http/config/HttpClientProperties.kt
@@ -7,4 +7,6 @@ import java.time.Duration
 data class HttpClientProperties(
     val connectTimeout: Duration = Duration.ofSeconds(2),
     val readTimeout: Duration = Duration.ofSeconds(25),
+    val oauth2ConnectTimeout: Duration = connectTimeout,
+    val oauth2ReadTimeout: Duration = Duration.ofSeconds(3),
 )

--- a/http-client/main/no/nav/tilleggsstonader/libs/http/config/RestTemplateConfiguration.kt
+++ b/http-client/main/no/nav/tilleggsstonader/libs/http/config/RestTemplateConfiguration.kt
@@ -19,7 +19,6 @@ import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.RestTemplate
 import tools.jackson.module.kotlin.jsonMapper
-import java.time.Duration
 
 @Suppress("SpringFacetCodeInspection")
 @Configuration
@@ -47,8 +46,8 @@ class RestTemplateConfiguration(
         val clientHttpRequestFactorySettings =
             HttpClientSettings
                 .defaults()
-                .withConnectTimeout(Duration.ofSeconds(1))
-                .withReadTimeout(Duration.ofSeconds(1))
+                .withConnectTimeout(httpClientProperties.oauth2ConnectTimeout)
+                .withReadTimeout(httpClientProperties.oauth2ReadTimeout)
         val requestFactory = ClientHttpRequestFactoryBuilder.detect().build(clientHttpRequestFactorySettings)
         val restClient =
             restClientBuilder

--- a/http-client/test/no/nav/tilleggsstonader/libs/http/client/RetryOAuth2HttpClientTest.kt
+++ b/http-client/test/no/nav/tilleggsstonader/libs/http/client/RetryOAuth2HttpClientTest.kt
@@ -1,17 +1,24 @@
 package no.nav.tilleggsstonader.libs.http.client
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
+import com.github.tomakehurst.wiremock.stubbing.Scenario
 import no.nav.security.token.support.client.core.http.OAuth2HttpHeaders
 import no.nav.security.token.support.client.core.http.OAuth2HttpRequest
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder
 import org.springframework.boot.http.client.HttpClientSettings
 import org.springframework.web.client.RestClient
@@ -20,28 +27,34 @@ import java.time.Duration
 import java.time.temporal.ChronoUnit
 
 internal class RetryOAuth2HttpClientTest {
-    val clientHttpRequestFactorySettings =
+    private val clientHttpRequestFactorySettings =
         HttpClientSettings
             .defaults()
             .withConnectTimeout(Duration.of(1, ChronoUnit.SECONDS))
             .withReadTimeout(Duration.of(1, ChronoUnit.SECONDS))
-    val requestFactory = ClientHttpRequestFactoryBuilder.detect().build(clientHttpRequestFactorySettings)
-    val restClient =
+    private val requestFactory = ClientHttpRequestFactoryBuilder.detect().build(clientHttpRequestFactorySettings)
+    private val restClient =
         RestClient
             .builder()
             .requestFactory(requestFactory)
             .build()
-    val client = RetryOAuth2HttpClient(restClient)
+    private val client = RetryOAuth2HttpClient(restClient)
+    private val logger = LoggerFactory.getLogger(RetryOAuth2HttpClient::class.java) as Logger
+    private val listAppender = ListAppender<ILoggingEvent>()
 
     @BeforeEach
     internal fun setUp() {
         wireMockServer.resetAll()
+        logger.detachAppender(listAppender)
+        listAppender.list.clear()
+        listAppender.start()
+        logger.addAppender(listAppender)
     }
 
     @Test
     internal fun `200 - skal kun kalle en gang`() {
-        stub(WireMock.aResponse().withBody("{}"))
-        post()
+        stub(successResponse())
+        assertThat(post()).isNull()
         wireMockServer.verify(1, RequestPatternBuilder.allRequests())
     }
 
@@ -80,6 +93,42 @@ internal class RetryOAuth2HttpClientTest {
         wireMockServer.verify(3, RequestPatternBuilder.allRequests())
     }
 
+    @Test
+    internal fun `skal logge info når retry lykkes`() {
+        wireMockServer.stubFor(
+            WireMock
+                .post(WireMock.anyUrl())
+                .inScenario("retry-lykkes")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willSetStateTo("andre-forsok")
+                .willReturn(successResponse().withFixedDelay(1200)),
+        )
+        wireMockServer.stubFor(
+            WireMock
+                .post(WireMock.anyUrl())
+                .inScenario("retry-lykkes")
+                .whenScenarioStateIs("andre-forsok")
+                .willReturn(successResponse()),
+        )
+
+        val exception = post()
+
+        assertThat(exception).isNull()
+        assertThat(loggmeldingerPå(Level.INFO)).hasSize(1)
+        assertThat(loggmeldingerPå(Level.WARN)).isEmpty()
+    }
+
+    @Test
+    internal fun `skal logge warning når alle retryforsok feiler`() {
+        stub(successResponse().withFixedDelay(1200))
+
+        val exception = post()
+
+        assertThat(exception).isNotNull()
+        assertThat(loggmeldingerPå(Level.INFO)).hasSize(2)
+        assertThat(loggmeldingerPå(Level.WARN)).hasSize(1)
+    }
+
     private fun stub(responseDefinitionBuilder: ResponseDefinitionBuilder?) {
         wireMockServer.stubFor(
             WireMock
@@ -87,6 +136,12 @@ internal class RetryOAuth2HttpClientTest {
                 .willReturn(responseDefinitionBuilder),
         )
     }
+
+    private fun successResponse(): ResponseDefinitionBuilder =
+        WireMock
+            .aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(SUCCESS_BODY)
 
     private fun post(): Exception? =
         try {
@@ -101,8 +156,11 @@ internal class RetryOAuth2HttpClientTest {
             e
         }
 
+    private fun loggmeldingerPå(level: Level): List<ILoggingEvent> = listAppender.list.filter { it.level == level }
+
     companion object {
         private lateinit var wireMockServer: WireMockServer
+        private const val SUCCESS_BODY = """{"access_token":"token","expires_in":3600,"token_type":"Bearer"}"""
 
         @BeforeAll
         @JvmStatic

--- a/http-client/test/no/nav/tilleggsstonader/libs/http/config/HttpClientPropertiesTest.kt
+++ b/http-client/test/no/nav/tilleggsstonader/libs/http/config/HttpClientPropertiesTest.kt
@@ -14,6 +14,8 @@ class HttpClientPropertiesTest {
 
         assertThat(properties.connectTimeout).isEqualTo(Duration.ofSeconds(2))
         assertThat(properties.readTimeout).isEqualTo(Duration.ofSeconds(25))
+        assertThat(properties.oauth2ConnectTimeout).isEqualTo(Duration.ofSeconds(2))
+        assertThat(properties.oauth2ReadTimeout).isEqualTo(Duration.ofSeconds(3))
     }
 
     @Test
@@ -22,12 +24,16 @@ class HttpClientPropertiesTest {
             mapOf(
                 "tilleggsstonader.http-client.connect-timeout" to "PT5S",
                 "tilleggsstonader.http-client.read-timeout" to "PT60S",
+                "tilleggsstonader.http-client.oauth2-connect-timeout" to "PT4S",
+                "tilleggsstonader.http-client.oauth2-read-timeout" to "PT7S",
             )
 
         val properties = bindProperties(source)
 
         assertThat(properties.connectTimeout).isEqualTo(Duration.ofSeconds(5))
         assertThat(properties.readTimeout).isEqualTo(Duration.ofSeconds(60))
+        assertThat(properties.oauth2ConnectTimeout).isEqualTo(Duration.ofSeconds(4))
+        assertThat(properties.oauth2ReadTimeout).isEqualTo(Duration.ofSeconds(7))
     }
 
     @Test
@@ -40,7 +46,9 @@ class HttpClientPropertiesTest {
         val properties = bindProperties(source)
 
         assertThat(properties.connectTimeout).isEqualTo(Duration.ofSeconds(10))
-        assertThat(properties.readTimeout).isEqualTo(Duration.ofSeconds(25)) // standard
+        assertThat(properties.readTimeout).isEqualTo(Duration.ofSeconds(25))
+        assertThat(properties.oauth2ConnectTimeout).isEqualTo(Duration.ofSeconds(10))
+        assertThat(properties.oauth2ReadTimeout).isEqualTo(Duration.ofSeconds(3))
     }
 
     private fun bindProperties(source: Map<String, String>): HttpClientProperties {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi har sett en del slike warnings i det siste: 

```
Kall mot url=https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/oauth2/v2.0/token feilet, cause=class java.net.SocketTimeoutException
```

Feilen ligger i henting av OAuth2-token fra Azure. Fra trace kan vi se at første token-kall timeouter etter 1 sekund, mens retry som regel går gjennom fint kort tid etter. Det gir unødvendig warning-støy og gjør klienten sårbar for små variasjoner i responstid fra Azure.

 Endringene som er gjort:
  - OAuth2-klienten bruker nå egne, konfigurerbare timeouter i stedet for hardkodet 1s/1s
  - standard for OAuth2 read-timeout er økt for å tåle kortvarig treghet bedre
  - retry beholdes, siden det trolig kan redde en del av kallene 💊
  - logging er justert slik warn kun brukes når alle retryforsøk er brukt opp
  - tester er oppdatert for nye properties og ønsket retry/logging

Målet med endringen er å redusere falske timeouts og warning-støy mot Azure token-endepunktet, uten å endre auth-flyt eller fjerne robustheten vi får av retry.