### PR TITLE
Diverse hjelpefunksjoner for UkeIÅr

### DIFF
--- a/util/main/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅr.kt
+++ b/util/main/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅr.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.libs.utils.dato
 import no.nav.tilleggsstonader.kontrakter.felles.Periode
 import no.nav.tilleggsstonader.kontrakter.felles.alleDatoer
 import java.time.LocalDate
+import java.time.temporal.WeekFields
 
 data class UkeIÅr(
     val ukenummer: Int,
@@ -15,6 +16,16 @@ data class UkeIÅr(
         }
 
     override fun toString(): String = "$år-$ukenummer"
+
+    fun alleDager(): List<LocalDate> {
+        val firstDayOfWeek =
+            LocalDate
+                .ofYearDay(år, 1)
+                .with(WeekFields.ISO.weekBasedYear(), år.toLong())
+                .with(WeekFields.ISO.weekOfWeekBasedYear(), ukenummer.toLong())
+                .with(WeekFields.ISO.dayOfWeek(), 1)
+        return (0L..6L).map { firstDayOfWeek.plusDays(it) }
+    }
 
     companion object {
         fun fraString(s: String): UkeIÅr {

--- a/util/main/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅr.kt
+++ b/util/main/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅr.kt
@@ -27,6 +27,8 @@ data class UkeIÅr(
         return (0L..6L).map { firstDayOfWeek.plusDays(it) }
     }
 
+    fun forrigeUke(): UkeIÅr = alleDager().first().minusDays(1).tilUkeIÅr()
+
     companion object {
         fun fraString(s: String): UkeIÅr {
             val split = s.split("-")

--- a/util/main/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅr.kt
+++ b/util/main/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅr.kt
@@ -29,6 +29,20 @@ data class UkeIÅr(
 
     fun forrigeUke(): UkeIÅr = alleDager().first().minusDays(1).tilUkeIÅr()
 
+    fun mandag() = alleDager()[0]
+
+    fun tirsdag() = alleDager()[1]
+
+    fun onsdag() = alleDager()[2]
+
+    fun torsdag() = alleDager()[3]
+
+    fun fredag() = alleDager()[4]
+
+    fun lørdag() = alleDager()[5]
+
+    fun søndag() = alleDager()[6]
+
     companion object {
         fun fraString(s: String): UkeIÅr {
             val split = s.split("-")
@@ -39,6 +53,10 @@ data class UkeIÅr(
 
             return UkeIÅr(uke, år)
         }
+
+        fun nå() = LocalDate.now().tilUkeIÅr()
+
+        fun forrigeUke() = nå().forrigeUke()
     }
 }
 

--- a/util/test/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅrTest.kt
+++ b/util/test/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅrTest.kt
@@ -60,6 +60,33 @@ class UkeIÅrTest {
     }
 
     @Test
+    fun `alleDager returnerer 7 dager for en gitt uke`() {
+        val dager = UkeIÅr(1, 2025).alleDager()
+        assertThat(dager).hasSize(7)
+    }
+
+    @Test
+    fun `alleDager starter på mandag og slutter på søndag`() {
+        val dager = UkeIÅr(1, 2025).alleDager()
+        assertThat(dager.first()).isEqualTo(java.time.LocalDate.of(2024, 12, 30)) // Uke 1 2025 starter 30. des 2024
+        assertThat(dager.last()).isEqualTo(java.time.LocalDate.of(2025, 1, 5))
+    }
+
+    @Test
+    fun `alleDager returnerer riktige dager for en uke midt i året`() {
+        val dager = UkeIÅr(19, 2026).alleDager()
+        assertThat(dager).hasSize(7)
+        assertThat(dager.first()).isEqualTo(java.time.LocalDate.of(2026, 5, 4))
+        assertThat(dager.last()).isEqualTo(java.time.LocalDate.of(2026, 5, 10))
+    }
+
+    @Test
+    fun `alleDager matcher tilUkeIÅr for alle dagene i uken`() {
+        val uke = UkeIÅr(19, 2026)
+        assertThat(uke.alleDager().map { it.tilUkeIÅr() }).containsOnly(uke)
+    }
+
+    @Test
     fun `Feiler ved ugyldig format`() {
         assertThatThrownBy { UkeIÅr.fraString("2026/15") }
             .isInstanceOf(IllegalArgumentException::class.java)

--- a/util/test/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅrTest.kt
+++ b/util/test/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅrTest.kt
@@ -98,7 +98,7 @@ class UkeIÅrTest {
         // Uke 1 i 2026 -> uke 53 i 2025 finnes ikke, siste uke er 52
         assertThat(UkeIÅr(1, 2026).forrigeUke()).isEqualTo(UkeIÅr(52, 2025))
         // Uke 1 i 2015 -> 2015 har 53 uker
-        assertThat(UkeIÅr(1, 2015).forrigeUke()).isEqualTo(UkeIÅr(53, 2015 - 1))
+        assertThat(UkeIÅr(1, 2015).forrigeUke()).isEqualTo(UkeIÅr(52, 2014))
     }
 
     @Test

--- a/util/test/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅrTest.kt
+++ b/util/test/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅrTest.kt
@@ -87,6 +87,20 @@ class UkeIÅrTest {
     }
 
     @Test
+    fun `forrigeUke returnerer uken før inneværende uke`() {
+        assertThat(UkeIÅr(10, 2026).forrigeUke()).isEqualTo(UkeIÅr(9, 2026))
+        assertThat(UkeIÅr(2, 2026).forrigeUke()).isEqualTo(UkeIÅr(1, 2026))
+    }
+
+    @Test
+    fun `forrigeUke håndterer årsskifte - uke 1 gir siste uke i forrige år`() {
+        // Uke 1 i 2026 -> uke 53 i 2025 finnes ikke, siste uke er 52
+        assertThat(UkeIÅr(1, 2026).forrigeUke()).isEqualTo(UkeIÅr(52, 2025))
+        // Uke 1 i 2015 -> 2015 har 53 uker
+        assertThat(UkeIÅr(1, 2015).forrigeUke()).isEqualTo(UkeIÅr(53, 2015 - 1))
+    }
+
+    @Test
     fun `Feiler ved ugyldig format`() {
         assertThatThrownBy { UkeIÅr.fraString("2026/15") }
             .isInstanceOf(IllegalArgumentException::class.java)

--- a/util/test/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅrTest.kt
+++ b/util/test/no/nav/tilleggsstonader/libs/utils/dato/UkeIÅrTest.kt
@@ -3,6 +3,7 @@ package no.nav.tilleggsstonader.libs.utils.dato
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
 
 class UkeIÅrTest {
     @Test
@@ -110,5 +111,17 @@ class UkeIÅrTest {
 
         assertThatThrownBy { UkeIÅr.fraString("2026-uke") }
             .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `ukedager-funksjoner returnerer korrekt dag`() {
+        val uke = UkeIÅr.nå()
+        assertThat(uke.mandag().dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+        assertThat(uke.tirsdag().dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
+        assertThat(uke.onsdag().dayOfWeek).isEqualTo(DayOfWeek.WEDNESDAY)
+        assertThat(uke.torsdag().dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
+        assertThat(uke.fredag().dayOfWeek).isEqualTo(DayOfWeek.FRIDAY)
+        assertThat(uke.lørdag().dayOfWeek).isEqualTo(DayOfWeek.SATURDAY)
+        assertThat(uke.søndag().dayOfWeek).isEqualTo(DayOfWeek.SUNDAY)
     }
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Hjelpefunksjoner i UkeIÅr for å hente ut alle dager i en gitt kalenderuke.

Nye instansmetoder:

| Metode | Beskrivelse |
|--------|-------------|
| `alleDager()` | Returnerer alle 7 dager (mandag–søndag) i uken som `List<LocalDate>` |
| `forrigeUke()` | Returnerer `UkeIÅr` for uken før — håndterer årsskifte korrekt |
| `mandag()` | Returnerer mandagen i uken |
| `tirsdag()` | Returnerer tirsdagen i uken |
| `onsdag()` | Returnerer onsdagen i uken |
| `torsdag()` | Returnerer torsdagen i uken |
| `fredag()` | Returnerer fredagen i uken |
| `lørdag()` | Returnerer lørdagen i uken |
| `søndag()` | Returnerer søndagen i uken |

Nye companion-metoder:

| Metode | Beskrivelse |
|--------|-------------|
| `UkeIÅr.nå()` | Returnerer inneværende uke basert på `LocalDate.now()` |
| `UkeIÅr.forrigeUke()` | Returnerer forrige uke — statisk snarvei for `nå().forrigeUke()` |
